### PR TITLE
Restore Maven 4 extension

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -24,6 +24,7 @@ excludes = [
     "plugin-gradle/src/main/java/com/tisonkun/os/gradle/OSDetector.java",
     "plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java",
     "plugin-maven/src/main/java/com/tisonkun/os/maven/DetectMojo.java",
+    "plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java",
     "plugin-maven/src/main/java/com/tisonkun/os/maven/RepositorySessionInjector.java",
 ]
 

--- a/plugin-maven/build.gradle.kts
+++ b/plugin-maven/build.gradle.kts
@@ -37,6 +37,7 @@ tasks.withType<GenerateHelpMojoSourcesTask>().configureEach {
 }
 
 dependencies {
+    compileOnly("org.apache.maven:maven-api-spi:4.0.0-alpha-13")
     compileOnly("org.apache.maven:maven-plugin-api:3.9.9")
     compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:3.11.0")
     implementation("org.apache.maven:maven-core:3.9.9")

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
@@ -70,6 +70,18 @@ import org.codehaus.plexus.util.InterpolationFilterReader;
 @Component(role = AbstractMavenLifecycleParticipant.class, hint = "detect-os")
 public class DetectExtension extends AbstractMavenLifecycleParticipant {
 
+    private static boolean disable;
+
+    /**
+     * When running in Maven 4, the interpolation of existing projects can be very slow.
+     * This allows disabling the interpolation of existing projects, as this Maven 4
+     * extension provides the properties early enough so that they are available for
+     * interpolation.
+     */
+    public static void disable() {
+        disable = true;
+    }
+
     private final Logger logger;
     private final Detector detector;
 
@@ -95,6 +107,9 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
     }
 
     private void injectProperties(MavenSession session) throws MavenExecutionException {
+        if (disable) {
+            return;
+        }
         final Map<String, String> dict = getProperties(session);
         // Inject the current session.
         injectSession(session, dict);

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 gnodet <gnodet@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tisonkun.os.maven;
+
+import com.tisonkun.os.core.Detector;
+import com.tisonkun.os.core.FileOperationProvider;
+import com.tisonkun.os.core.SystemPropertyOperationProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import javax.inject.Inject;
+import org.apache.maven.api.spi.PropertyContributor;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Set Maven session user properties.
+ */
+@Component(role = PropertyContributor.class)
+public class DetectPropertyContributor implements PropertyContributor {
+
+    private final Logger logger;
+
+    @Inject
+    DetectPropertyContributor(Logger logger) {
+        super();
+        this.logger = logger;
+    }
+
+    @Override
+    public void contribute(Map<String, String> map) {
+        DetectExtension.disable();
+
+        final Properties props = new Properties();
+        props.putAll(map);
+
+        final Detector detector =
+                new Detector(new SimpleSystemPropertyOperations(map), new SimpleFileOperations(), logger::info);
+        detector.detect(props, getClassifierWithLikes(map));
+    }
+
+    /**
+     * Inspects the session's user and project properties for the {@link
+     * DetectMojo#CLASSIFIER_WITH_LIKES_PROPERTY} and separates the property into a list.
+     */
+    private static List<String> getClassifierWithLikes(Map<String, String> map) {
+        // Check to see if the project defined the
+        return DetectMojo.getClassifierWithLikes(map.get(DetectMojo.CLASSIFIER_WITH_LIKES_PROPERTY));
+    }
+
+    private static class SimpleSystemPropertyOperations implements SystemPropertyOperationProvider {
+        final Map<String, String> map;
+
+        private SimpleSystemPropertyOperations(Map<String, String> map) {
+            this.map = map;
+        }
+
+        @Override
+        public String getSystemProperty(String name) {
+            return System.getProperty(name);
+        }
+
+        @Override
+        public String getSystemProperty(String name, String def) {
+            return System.getProperty(name, def);
+        }
+
+        @Override
+        public String setSystemProperty(String name, String value) {
+            map.put(name, value);
+            return System.setProperty(name, value);
+        }
+    }
+
+    private static class SimpleFileOperations implements FileOperationProvider {
+        @Override
+        public InputStream readFile(String fileName) throws IOException {
+            return Files.newInputStream(Paths.get(fileName));
+        }
+    }
+}

--- a/plugin-maven/src/main/resources/META-INF/plexus/components.xml
+++ b/plugin-maven/src/main/resources/META-INF/plexus/components.xml
@@ -25,5 +25,12 @@
             <description/>
             <isolated-realm>false</isolated-realm>
         </component>
+        <component>
+            <role>org.apache.maven.api.spi.PropertyContributor</role>
+            <role-hint>detect-os</role-hint>
+            <implementation>com.tisonkun.os.maven.DetectPropertyContributor</implementation>
+            <description/>
+            <isolated-realm>false</isolated-realm>
+        </component>
     </components>
 </component-set>


### PR DESCRIPTION
After trying the current main branch, I restored the Maven 4 specific extension.  
The reason is that Maven 4 provides a specific extension point for this very usage, and the execution time is way faster than having to go through all projects to manually interpolate all properties.
In a project such as Apache Camel (roughly 500 subprojects), the time spend when running Maven 4 with the previous extension is almost 4 seconds at startup, and just nothin with this PR.
@tisonkun 