### PR TITLE
Tone down Maven plugin output

### DIFF
--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
@@ -98,6 +98,9 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
 
     @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
+        if (!disable) {
+            logger.info("The os-detector extension is registered, OS and CPU architecture properties will be provided.");
+        }
         injectProperties(session);
     }
 

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
@@ -93,7 +93,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
     @Inject
     public DetectExtension(final Logger logger) {
         this.logger = logger;
-        this.detector = new Detector(new DefaultSystemPropertyOperations(), new DefaultFileOperations(), logger::info);
+        this.detector = new Detector(new DefaultSystemPropertyOperations(), new DefaultFileOperations(), logger::debug);
     }
 
     @Override

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
@@ -99,7 +99,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
     @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
         if (!disable) {
-            logger.info("The os-detector extension is registered, OS and CPU architecture properties will be provided.");
+            logger.info("The os-detector Maven 3 extension is registered, OS and CPU architecture properties will be provided.");
         }
         injectProperties(session);
     }

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectExtension.java
@@ -99,7 +99,8 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
     @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
         if (!disable) {
-            logger.info("The os-detector Maven 3 extension is registered, OS and CPU architecture properties will be provided.");
+            logger.info(
+                    "The os-detector Maven 3 extension is registered, OS and CPU architecture properties will be provided.");
         }
         injectProperties(session);
     }

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
@@ -47,7 +47,7 @@ public class DetectPropertyContributor implements PropertyContributor {
 
     @Override
     public void contribute(Map<String, String> map) {
-        logger.info("The os-detector extension is registered, OS and CPU architecture properties will be provided.");
+        logger.info("The os-detector Maven 4 extension is registered, OS and CPU architecture properties will be provided.");
         DetectExtension.disable();
 
         final Properties props = new Properties();

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
@@ -47,7 +47,8 @@ public class DetectPropertyContributor implements PropertyContributor {
 
     @Override
     public void contribute(Map<String, String> map) {
-        logger.info("The os-detector Maven 4 extension is registered, OS and CPU architecture properties will be provided.");
+        logger.info(
+                "The os-detector Maven 4 extension is registered, OS and CPU architecture properties will be provided.");
         DetectExtension.disable();
 
         final Properties props = new Properties();

--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/DetectPropertyContributor.java
@@ -47,13 +47,14 @@ public class DetectPropertyContributor implements PropertyContributor {
 
     @Override
     public void contribute(Map<String, String> map) {
+        logger.info("The os-detector extension is registered, OS and CPU architecture properties will be provided.");
         DetectExtension.disable();
 
         final Properties props = new Properties();
         props.putAll(map);
 
         final Detector detector =
-                new Detector(new SimpleSystemPropertyOperations(map), new SimpleFileOperations(), logger::info);
+                new Detector(new SimpleSystemPropertyOperations(map), new SimpleFileOperations(), logger::debug);
         detector.detect(props, getClassifierWithLikes(map));
     }
 


### PR DESCRIPTION
The current output for a project that uses this Maven extension is the following (when running with Maven 3.x):
```
➜  camel git:(cleanup-dep-mgmt) ~/.sdkman/candidates/maven/3.9.8/bin/mvn foo     
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 14.6
[INFO] os.detected.version.major: 14
[INFO] os.detected.version.minor: 6
[INFO] os.detected.classifier: osx-aarch_64
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 14.6
[INFO] os.detected.version.major: 14
[INFO] os.detected.version.minor: 6
[INFO] os.detected.classifier: osx-aarch_64
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Camel                                                              [pom]
[INFO] Camel :: Buildtools                                                [jar]
[INFO] Camel :: Parent                                                    [pom]
```

This is really verbose (and duplicate), so I'd suggest to just move all the log to debug in Maven.