### PR TITLE
build: only signing on release 

### DIFF
--- a/buildSrc/src/main/kotlin/java-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-publish.gradle.kts
@@ -67,8 +67,12 @@ publishing {
     }
 }
 
-if (!System.getenv("GITHUB_WORKFLOW").equals("CI", true)) {
-    signing {
-        sign(publishing.publications["mavenJava"])
+signing {
+    setRequired {
+        val releaseVersion = !version.toString().endsWith("-SNAPSHOT")
+        // signing is required if this is a release version and the artifacts are to be published
+        // do not use hasTask() as this require realization of the tasks that maybe are not necessary
+        releaseVersion && gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
     }
+    sign(publishing.publications["mavenJava"])
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 group=com.tisonkun.os
-version=0.4.0
+version=0.5.0

--- a/plugin-gradle/build.gradle.kts
+++ b/plugin-gradle/build.gradle.kts
@@ -77,8 +77,12 @@ publishing {
     }
 }
 
-if (!System.getenv("GITHUB_WORKFLOW").equals("CI", true)) {
-    signing {
-        sign(publishing.publications)
+signing {
+    setRequired {
+        val releaseVersion = !version.toString().endsWith("-SNAPSHOT")
+        // signing is required if this is a release version and the artifacts are to be published
+        // do not use hasTask() as this require realization of the tasks that maybe are not necessary
+        releaseVersion && gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
     }
+    sign(publishing.publications)
 }


### PR DESCRIPTION
This closes https://github.com/tisonkun/os-detector/issues/10.

@gnodet you can test if this helps when `./gradlew publishToMavenLocal`.