### PR TITLE
fix: NoSuchMethodException: ...FilterRepositorySystemSession.getSystemProperties

### DIFF
--- a/plugin-maven/src/main/java/com/tisonkun/os/maven/RepositorySessionInjector.java
+++ b/plugin-maven/src/main/java/com/tisonkun/os/maven/RepositorySessionInjector.java
@@ -21,7 +21,7 @@ final class RepositorySessionInjector {
             // Both interfaces have getSystemProperties() accessor method that returns Map<String, String>.
             final Object repoSession = session.getRepositorySession();
             final Class<?> cls = repoSession.getClass();
-            final Method getSystemPropertiesMethod = cls.getDeclaredMethod("getSystemProperties");
+            final Method getSystemPropertiesMethod = cls.getMethod("getSystemProperties");
             repoSessionProps = (Map<String, String>) getSystemPropertiesMethod.invoke(repoSession);
             try {
                 repoSessionProps.putAll(dict);


### PR DESCRIPTION
When executed via M2E the Eclipse Maven integration the following error is thrown:
```
!ENTRY org.eclipse.m2e.logback.appender 2 0 2024-10-22 15:14:04.572
!MESSAGE Failed to inject repository session properties. org.eclipse.m2e.core.internal.embedder.FilterRepositorySystemSession.getSystemProperties()
!STACK 0
java.lang.NoSuchMethodException: org.eclipse.m2e.core.internal.embedder.FilterRepositorySystemSession.getSystemProperties()
	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2848)
	at com.tisonkun.os.maven.RepositorySessionInjector.injectRepositorySession(RepositorySessionInjector.java:24)
	at com.tisonkun.os.maven.DetectExtension.injectSession(DetectExtension.java:192)
	at com.tisonkun.os.maven.DetectExtension.injectProperties(DetectExtension.java:119)
	at com.tisonkun.os.maven.DetectExtension.afterProjectsRead(DetectExtension.java:110)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.executeParticipants(ProjectRegistryManager.java:828)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.lambda$15(ProjectRegistryManager.java:795)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:339)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:278)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.lambda$14(ProjectRegistryManager.java:794)
	at java.base/java.util.HashMap$Values.forEach(HashMap.java:1073)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.lambda$11(ProjectRegistryManager.java:792)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:339)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:278)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.readMavenProjectFacades(ProjectRegistryManager.java:764)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.refresh(ProjectRegistryManager.java:470)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.refresh(ProjectRegistryManager.java:370)
	at org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager.refresh(ProjectRegistryManager.java:322)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.getProjectFacade(MavenBuilder.java:146)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.lambda$0(MavenBuilder.java:84)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:339)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:278)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.execute(MavenBuilder.java:83)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder.build(MavenBuilder.java:192)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:1077)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:296)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:352)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:441)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:444)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:555)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:503)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:585)
	at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:207)
	at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:300)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

```